### PR TITLE
Fix index out of bounds error

### DIFF
--- a/ordertwolists.nim
+++ b/ordertwolists.nim
@@ -1,5 +1,5 @@
 proc `<`[T](a, b: openarray[T]): bool =
-  for i in 0 .. min(a.len, b.len):
+  for i in 0 .. <min(a.len, b.len):
     if a[i] < b[i]: return true
     if a[i] > b[i]: return false
   return a.len < b.len


### PR DESCRIPTION
`echo([1,2,3] < [1,2,3])` 

results in :

```Traceback (most recent call last)
ordertwolists.nim(14)    ordertwolists
ordertwolists.nim(10)    <
system.nim(2581)         sysFatal
Error: unhandled exception: index out of bounds [IndexError]
```

```
Nim Compiler Version 0.16.0 (2017-01-08) [MacOSX: amd64]
Copyright (c) 2006-2017 by Andreas Rumpf

git hash: 5947403e84ba44397b35f93f9d327c76e794210f
active boot switches: -d:release
```